### PR TITLE
changed from `sbot` to `ssb-server`

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -25,7 +25,7 @@ if (cmd === 'publish') {
       var key = fs.readFileSync(path.join('.ssb-web', 'key'), 'utf-8')
       fs.writeFileSync(path.join('.ssb-web', 'root'), hash, 'utf-8')
       var args = ['publish', '--type', 'web-root', '--root', hash, '--site', key]
-      spawn('sbot', args)
+      spawn('ssb-server', args)
         .once('exit', function (code) {
           if (!code) console.log('Published dynamic ssb-web site:', key, '('+encodeURIComponent(key)+')')
           else console.log('error', code)

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
 function init (cb) {
   cb = once(cb)
 
-  var p = spawn('sbot', 'publish --type web-init'.split(' '))
+  var p = spawn('ssb-server', 'publish --type web-init'.split(' '))
 
   collect(p.stdout, function (err, res) {
     if (err) return cb(err)
@@ -25,7 +25,7 @@ function init (cb) {
   })
 
   p.once('exit', function (code) {
-    if (code) cb(new Error('sbot error code ' + code))
+    if (code) cb(new Error('ssb-server error code ' + code))
   })
 }
 
@@ -43,7 +43,7 @@ function publish (filename, cb) {
 }
 
 function wrapData (data, cb) {
-  var p = spawn('sbot', ['blobs.add'])
+  var p = spawn('ssb-server', ['blobs.add'])
   p.stdin.end(data)
   collect(p.stdout, function (err, res) {
     cb(err, res ? res.toString().trim() : undefined)


### PR DESCRIPTION
this is more than a cosmetic change. using `sbot` was causing the deprecation warning to be included in the `root` attribute which was breaking the backlinks queries due to a malformed hash. switching to `ssb-server` fixes this. 

see the `root` field below.

```
{ key: '%cRRgNMoRSsj/rLjOvnrgxcqXF46e4+9W3bWWzTekf2o=.sha256',
  value:
   { previous: '%fzvyPQ9cQZG4AAT2GeoDSGAP2xQaU5BEgiA5hE+YBgI=.sha256',
     sequence: 369,
     author: '@VelntasZy86CuIihzSpkzPvIOYgyu3FO3NZww/UOirk=.ed25519',
     timestamp: 1554567163643,
     hash: 'sha256',
     content:
      { type: 'web-root',
        root:
         'WARNING-DEPRECATION: `sbot` has been renamed to `ssb-server`\n&0ngovfo6+hCXtdVZuS10i5mZ2Ks+x6MzCbVRudGpTkM=.sha256',
        site: '%wvRo2yjx7hMK/st8OzScCmadfeNLeotjPsKyR5vGon0=.sha256' },
     signature:
      'u4NQSVvpmxEnWxLWRPckUapUCNug1Y4eMMDIMUdBFGtQ1TDxXBKoFbYroAgjIQWTF4YxO4xKutQpHW1RZdy6DA==.sig.ed25519' },
  timestamp: 1554567163644,
  dest: '%wvRo2yjx7hMK/st8OzScCmadfeNLeotjPsKyR5vGon0=.sha256',
  rts: 1554567163643 
}
```

p.s. THANK YOU for this project! it's so cool 💯 🥇